### PR TITLE
update: remove apple.com

### DIFF
--- a/chinadomain.list
+++ b/chinadomain.list
@@ -2015,7 +2015,6 @@ appgame.com
 appinn.com
 appjiagu.com
 apple-mapkit.com
-apple.com
 apple2003.com
 appsimg.com
 appsina.com
@@ -2691,7 +2690,6 @@ cdgtw.net
 cdjjedu.net
 cdjsjx.com
 cdlkzb.com
-cdn-apple.com
 cdn.jsdelivr.net
 cdn20.com
 cdn86.net

--- a/chinadomain.txt
+++ b/chinadomain.txt
@@ -2015,7 +2015,6 @@ appgame.com
 appinn.com
 appjiagu.com
 apple-mapkit.com
-apple.com
 apple2003.com
 appsimg.com
 appsina.com
@@ -2691,7 +2690,6 @@ cdgtw.net
 cdjjedu.net
 cdjsjx.com
 cdlkzb.com
-cdn-apple.com
 cdn.jsdelivr.net
 cdn20.com
 cdn86.net


### PR DESCRIPTION
Remove apple.com in chinadomain because it's already in nonchinadomain https://github.com/txthinking/bypass/blob/4aed16d1a3f458af6037b2808e897bfdf3a6e793/nonchinadomain.txt#L799-L800
The connection of apple music is really bad when I use bypass mode in brook